### PR TITLE
Fix Evaluation Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,10 @@ Use `style.py` to train a new style transfer network. Run `python style.py` to v
 ### Evaluating Style Transfer Networks
 Use `evaluate.py` to evaluate a style transfer network. Run `python evaluate.py` to view all the possible parameters. Evaluation takes 100 ms per frame (when batch size is 1) on a Maxwell Titan X. [More detailed documentation here](docs.md#evaluate). Takes several seconds per frame on a CPU. **Models for evaluation are [located here](https://www.dropbox.com/sh/exlysa7n1j397fp/AACl7lXX4mkTBZP14uX709Npa?dl=0)**. Example usage:
 
-    python evaluate.py --style examples/style/wave.jpg \
-      --checkpoint-dir saver \
-      --in-path all_frames/ \
-      --out-path transformed_frames/ \
-      --device /gpu:2 \
-      --batch-size 20
+    python evaluate.py --checkpoint scream.ckpt \
+      --in-path examples/thumb/ \
+      --out-path examples/results/
+
 
 ### Stylizing Video
 Use `transform_video.py` to transfer style into a video. Run `python transform_video.py` to view all the possible parameters. Requires `ffmpeg`. [More detailed documentation here](docs.md#video). Example usage:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Use `evaluate.py` to evaluate a style transfer network. Run `python evaluate.py`
       --in-path examples/thumb/ \
       --out-path examples/results/
 
-
 ### Stylizing Video
 Use `transform_video.py` to transfer style into a video. Run `python transform_video.py` to view all the possible parameters. Requires `ffmpeg`. [More detailed documentation here](docs.md#video). Example usage:
 


### PR DESCRIPTION
Current evaluation example did not match documentation. Fixed it with an example that will run with the repository as-is and a provided `ckpt` file, and will run even on weak computers.