### PR TITLE
Allow style transfer to images of different dimensions

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -28,6 +28,7 @@
 - `--out-path`: Out path of transformed image or out directory to put transformed images from in directory (if `in_path` is a directory). Required.
 - `--device`: Device used to transform image. Default: `/cpu:0`.
 - `--batch-size`: Batch size used to evaluate images. In particular meant for directory transformations. Default: `4`.
+- `--allow-different-dimensions`: Allow different image dimensions. Default: not enabled
 
 ## transform_video.py
 `transform_video.py` transforms videos into stylized videos given a style transfer net.

--- a/evaluate.py
+++ b/evaluate.py
@@ -27,7 +27,8 @@ def ffwd(data_in, paths_out, checkpoint_dir, device_t='/gpu:0', batch_size=4):
     curr_num = 0
     soft_config = tf.ConfigProto(allow_soft_placement=True)
     soft_config.gpu_options.allow_growth = True
-    with g.as_default(), g.device(device_t), tf.Session(config=soft_config) as sess:
+    with g.as_default(), g.device(device_t), \
+            tf.Session(config=soft_config) as sess:
         batch_shape = (batch_size,) + img_shape
         img_placeholder = tf.placeholder(tf.float32, shape=batch_shape,
                                          name='img_placeholder')
@@ -52,7 +53,9 @@ def ffwd(data_in, paths_out, checkpoint_dir, device_t='/gpu:0', batch_size=4):
                 X = np.zeros(batch_shape, dtype=np.float32)
                 for j, path_in in enumerate(curr_batch_in):
                     img = get_img(path_in)
-                    assert img.shape == img_shape, 'Images have different dimensions. Resize images or use --allow_different_dimensions.'
+                    assert img.shape == img_shape, \
+                        'Images have different dimensions. ' +  \
+                        'Resize images or use --allow_different_dimensions.'
                     X[j] = img
             else:
                 X = data_in[pos:pos+batch_size]
@@ -64,13 +67,15 @@ def ffwd(data_in, paths_out, checkpoint_dir, device_t='/gpu:0', batch_size=4):
         remaining_in = data_in[num_iters*batch_size:]
         remaining_out = paths_out[num_iters*batch_size:]
     if len(remaining_in) > 0:
-        ffwd(remaining_in, remaining_out, checkpoint_dir, device_t=device_t, batch_size=1)
+        ffwd(remaining_in, remaining_out, checkpoint_dir, 
+            device_t=device_t, batch_size=1)
 
 def ffwd_to_img(in_path, out_path, checkpoint_dir, device='/cpu:0'):
     paths_in, paths_out = [in_path], [out_path]
     ffwd(paths_in, paths_out, checkpoint_dir, batch_size=1, device_t=device)
 
-def ffwd_different_dimensions(in_path, out_path, checkpoint_dir, device_t=DEVICE, batch_size=4):
+def ffwd_different_dimensions(in_path, out_path, checkpoint_dir, 
+            device_t=DEVICE, batch_size=4):
     in_path_of_shape = defaultdict(list)
     out_path_of_shape = defaultdict(list)
     for i in range(len(in_path)):
@@ -81,12 +86,14 @@ def ffwd_different_dimensions(in_path, out_path, checkpoint_dir, device_t=DEVICE
         out_path_of_shape[shape].append(out_image)
     for shape in in_path_of_shape:
         print('Processing images of shape %s' % shape)
-        ffwd(in_path_of_shape[shape], out_path_of_shape[shape], checkpoint_dir, device_t, batch_size)
+        ffwd(in_path_of_shape[shape], out_path_of_shape[shape], 
+            checkpoint_dir, device_t, batch_size)
 
 def build_parser():
     parser = ArgumentParser()
     parser.add_argument('--checkpoint', type=str,
-                        dest='checkpoint_dir',help='dir or .ckpt file to load checkpoint from',
+                        dest='checkpoint_dir',
+                        help='dir or .ckpt file to load checkpoint from',
                         metavar='CHECKPOINT', required=True)
 
     parser.add_argument('--in-path', type=str,
@@ -107,7 +114,8 @@ def build_parser():
                         metavar='BATCH_SIZE', default=BATCH_SIZE)
 
     parser.add_argument('--allow-different-dimensions', action='store_true',
-                        dest='allow_different_dimensions', help='allow different image dimensions')
+                        dest='allow_different_dimensions', 
+                        help='allow different image dimensions')
 
     return parser
 
@@ -125,7 +133,8 @@ def main():
 
     if not os.path.isdir(opts.in_path):
         if os.path.exists(opts.out_path) and os.path.isdir(opts.out_path):
-            out_path = os.path.join(opts.out_path,os.path.basename(opts.in_path))
+            out_path = \
+                    os.path.join(opts.out_path,os.path.basename(opts.in_path))
         else:
             out_path = opts.out_path
 
@@ -136,8 +145,8 @@ def main():
         full_in = map(lambda x: os.path.join(opts.in_path,x), files)
         full_out = map(lambda x: os.path.join(opts.out_path,x), files)
         if opts.allow_different_dimensions:
-            ffwd_different_dimensions(full_in, full_out, opts.checkpoint_dir, device_t=opts.device,
-                    batch_size=opts.batch_size)
+            ffwd_different_dimensions(full_in, full_out, opts.checkpoint_dir, 
+                    device_t=opts.device, batch_size=opts.batch_size)
         else :
             ffwd(full_in, full_out, opts.checkpoint_dir, device_t=opts.device,
                     batch_size=opts.batch_size)


### PR DESCRIPTION
Allow multiple input images of different dimensions:
First inspect all images to group them by shape, then run one TF session for each distinct shape.

Two thoughts regarding performance:
* We're loading images twice: Once to get their size, and once during processing. This requires extra I/O and processing but avoids running out of memory for large folders.
* We're running multiple TF sessions. There is no technical alternative to this because of input dimensions, so this is the price of improved usability due to being able to use images of different size.