### PR TITLE
Implemented piping without saving each frame to disk as an option

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -83,12 +83,15 @@ def from_pipe(opts):
                 raw_image = pipe_in.stdout.read(width * height * 3)
 
                 if len(raw_image) != nbytes:
-                    last = True
-                    X = X[:count]
-                    batch_shape = (count, height, width, 3)
-                    img_placeholder = tf.placeholder(tf.float32, shape=batch_shape,
+                    if count == 0:
+                        read_input = False
+                    else:
+                        last = True
+                        X = X[:count]
+                        batch_shape = (count, height, width, 3)
+                        img_placeholder = tf.placeholder(tf.float32, shape=batch_shape,
                                                      name='img_placeholder')
-                    preds = transform.net(img_placeholder)
+                        preds = transform.net(img_placeholder)
                     break
 
                 image = numpy.fromstring(raw_image, dtype='uint8')

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 sys.path.insert(0, 'src')
 import transform, numpy as np, vgg, pdb, os
@@ -27,14 +28,16 @@ def from_pipe(opts):
     fps = round(eval(info["streams"][0]["r_frame_rate"]))
 
     command = ["ffmpeg",
+               '-loglevel', "quiet",
                '-i', opts.in_path,
                '-f', 'image2pipe',
                '-pix_fmt', 'rgb24',
                '-vcodec', 'rawvideo', '-']
 
-    pipe_in = subprocess.Popen(command, stdout=subprocess.PIPE, bufsize=10 ** 9)
+    pipe_in = subprocess.Popen(command, stdout=subprocess.PIPE, bufsize=10 ** 9, stdin=None, stderr=None)
 
     command = ["ffmpeg",
+               '-loglevel', "info",
                '-y',  # (optional) overwrite output file if it exists
                '-f', 'rawvideo',
                '-vcodec', 'rawvideo',
@@ -43,10 +46,12 @@ def from_pipe(opts):
                '-r', str(fps),  # frames per second
                '-i', '-',  # The imput comes from a pipe
                '-an',  # Tells FFMPEG not to expect any audio
-               # '-vcodec', 'libx264',
+               '-c:v', 'libx264',
+               '-preset', 'slow',
+               '-crf', '18',
                opts.out]
 
-    pipe_out = subprocess.Popen(command, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    pipe_out = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=None, stderr=None)
     g = tf.Graph()
     soft_config = tf.ConfigProto(allow_soft_placement=True)
     soft_config.gpu_options.allow_growth = True
@@ -70,42 +75,47 @@ def from_pipe(opts):
         X = np.zeros(batch_shape, dtype=np.float32)
         nbytes = 3 * width * height
         read_input = True
+        last = False
 
         while read_input:
-            for i in range(0, opts.batch_size):
+            count = 0
+            while count < opts.batch_size:
                 raw_image = pipe_in.stdout.read(width * height * 3)
 
                 if len(raw_image) != nbytes:
-                    read_input = False
+                    last = True
+                    X = X[:count]
+                    batch_shape = (count, height, width, 3)
+                    img_placeholder = tf.placeholder(tf.float32, shape=batch_shape,
+                                                     name='img_placeholder')
+                    preds = transform.net(img_placeholder)
                     break
 
                 image = numpy.fromstring(raw_image, dtype='uint8')
                 image = image.reshape((height, width, 3))
-                X[i] = image
+                X[count] = image
+                count += 1
 
             if read_input:
+                if last:
+                    read_input = False
                 _preds = sess.run(preds, feed_dict={img_placeholder: X})
 
-                for i in range(0, opts.batch_size):
+                for i in range(0, batch_shape[0]):
                     img = np.clip(_preds[i], 0, 255).astype(np.uint8)
                     try:
                         pipe_out.stdin.write(img)
                     except IOError as err:
                         ffmpeg_error = pipe_out.stderr.read()
-                        error = (str(err) + ("\n\nMoviePy error: FFMPEG encountered "
+                        error = (str(err) + ("\n\nFFMPEG encountered"
                                              "the following error while writing file:"
                                              "\n\n %s" % ffmpeg_error))
-                        pipe_out.stdin.close()
-                        pipe_in.stdout.close()
-                        pipe_out.terminate()
-                        pipe_in.terminate()
-                        del pipe_in
-                        del pipe_out
-                        raise IOError(error)
-        pipe_out.stdin.close()
-        pipe_in.stdout.close()
+                        read_input = False
+                        print(error)
         pipe_out.terminate()
         pipe_in.terminate()
+        pipe_out.stdin.close()
+        pipe_in.stdout.close()
         del pipe_in
         del pipe_out
 

--- a/transform_video.py
+++ b/transform_video.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from argparse import ArgumentParser
 import sys
 sys.path.insert(0, 'src')
@@ -59,8 +60,8 @@ def main():
 
     subprocess.call(" ".join(in_args), shell=True)
     base_names = list_files(in_dir)
-    in_files = map(lambda x: os.path.join(in_dir, x), base_names)
-    out_files = map(lambda x: os.path.join(out_dir, x), base_names)
+    in_files = list(map(lambda x: os.path.join(in_dir, x), base_names))
+    out_files = list(map(lambda x: os.path.join(out_dir, x), base_names))
     evaluate.ffwd(in_files, out_files, opts.checkpoint, device_t=opts.device,
                   batch_size=opts.batch_size)
     fr = 30 # wtf
@@ -75,7 +76,7 @@ def main():
     ]
 
     subprocess.call(" ".join(out_args), shell=True)
-    print 'Video at: %s' % opts.out
+    print('Video at: %s' % opts.out)
     shutil.rmtree(opts.tmp_dir)
  
 if __name__ == '__main__':

--- a/transform_video.py
+++ b/transform_video.py
@@ -35,6 +35,10 @@ def build_parser():
     parser.add_argument('--batch-size', type=int,
                         dest='batch_size',help='batch size for eval. default 4.',
                         metavar='BATCH_SIZE', default=BATCH_SIZE)
+
+    parser.add_argument('--no-disk', type=bool, dest='no_disk',
+                        help='Don\'t save intermediate files to disk. Default False',
+                        metavar='NO_DISK', default=False)
     return parser
 
 def check_opts(opts):
@@ -44,40 +48,43 @@ def check_opts(opts):
 def main():
     parser = build_parser()
     opts = parser.parse_args()
-    
-    in_dir = os.path.join(opts.tmp_dir, 'in')
-    out_dir = os.path.join(opts.tmp_dir, 'out')
-    if not os.path.exists(in_dir):
-        os.makedirs(in_dir)
-    if not os.path.exists(out_dir):
-        os.makedirs(out_dir)
 
-    in_args = [
-        'ffmpeg',
-        '-i', opts.in_path,
-        '%s/frame_%%d.png' % in_dir
-    ]
+    if opts.no_disk:
+        evaluate.from_pipe(opts)
+    else:
+        in_dir = os.path.join(opts.tmp_dir, 'in')
+        out_dir = os.path.join(opts.tmp_dir, 'out')
+        if not os.path.exists(in_dir):
+            os.makedirs(in_dir)
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
 
-    subprocess.call(" ".join(in_args), shell=True)
-    base_names = list_files(in_dir)
-    in_files = list(map(lambda x: os.path.join(in_dir, x), base_names))
-    out_files = list(map(lambda x: os.path.join(out_dir, x), base_names))
-    evaluate.ffwd(in_files, out_files, opts.checkpoint, device_t=opts.device,
-                  batch_size=opts.batch_size)
-    fr = 30 # wtf
-    out_args = [
-        'ffmpeg',
-        '-i', '%s/frame_%%d.png' % out_dir,
-        '-f', 'mp4',
-        '-q:v', '0',
-        '-vcodec', 'mpeg4',
-        '-r', str(fr),
-        opts.out
-    ]
+        in_args = [
+            'ffmpeg',
+            '-i', opts.in_path,
+            '%s/frame_%%d.png' % in_dir
+        ]
 
-    subprocess.call(" ".join(out_args), shell=True)
-    print('Video at: %s' % opts.out)
-    shutil.rmtree(opts.tmp_dir)
+        subprocess.call(" ".join(in_args), shell=True)
+        base_names = list_files(in_dir)
+        in_files = list(map(lambda x: os.path.join(in_dir, x), base_names))
+        out_files = list(map(lambda x: os.path.join(out_dir, x), base_names))
+        evaluate.ffwd(in_files, out_files, opts.checkpoint, device_t=opts.device,
+                      batch_size=opts.batch_size)
+        fr = 30 # wtf
+        out_args = [
+            'ffmpeg',
+            '-i', '%s/frame_%%d.png' % out_dir,
+            '-f', 'mp4',
+            '-q:v', '0',
+            '-vcodec', 'mpeg4',
+            '-r', str(fr),
+            opts.out
+        ]
+
+        subprocess.call(" ".join(out_args), shell=True)
+        print('Video at: %s' % opts.out)
+        shutil.rmtree(opts.tmp_dir)
  
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I got best performance when setting --batch-size to 1.

When timing the execution time, using a batch size of 4 on the original script, it is ~350% slower than using --no-disk = True and a batch size of 1.

Worth mentioning is I use an 7200 rpm HDD.