### PR TITLE
src modularization

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -1,12 +1,17 @@
-import sys
-sys.path.insert(0, 'src')
-import transform, numpy as np, vgg, pdb, os
-import scipy.misc
-import tensorflow as tf
-from utils import save_img, get_img, exists, list_files
 from argparse import ArgumentParser
 from collections import defaultdict
+import sys
 import time
+
+import numpy as np
+import pdb
+import os
+import scipy.misc
+import tensorflow as tf
+
+from src import transform,vgg
+from src.utils import save_img, get_img, exists, list_files
+
 
 BATCH_SIZE = 4
 DEVICE = '/gpu:0'


### PR DESCRIPTION
The use of sys.path.insert(0, 'src') discouraged.
Instead I 'have modularized your src folder (create a __init__.py file) and rewritten the imports in evaluate.py

Now I can call evaluate.py from outside the folder.