### PR TITLE
Fix imports and modularize `src/`

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -1,13 +1,11 @@
 from __future__ import print_function
-import sys
-sys.path.insert(0, 'src')
-import transform, numpy as np, vgg, pdb, os
-import scipy.misc
+
+from src import transform, vgg
+import numpy as np, os
 import tensorflow as tf
-from utils import save_img, get_img, exists, list_files
+from src.utils import save_img, get_img, exists, list_files
 from argparse import ArgumentParser
 from collections import defaultdict
-import time
 import json
 import subprocess
 import numpy

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -1,9 +1,10 @@
 from __future__ import print_function
 import functools
-import vgg, pdb, time
+from . import vgg
+import pdb, time
 import tensorflow as tf, numpy as np, os
-import transform
-from utils import get_img
+from . import transform
+from .utils import get_img
 
 STYLE_LAYERS = ('relu1_1', 'relu2_1', 'relu3_1', 'relu4_1', 'relu5_1')
 CONTENT_LAYER = 'relu4_2'

--- a/src/transform.py
+++ b/src/transform.py
@@ -1,4 +1,5 @@
-import tensorflow as tf, pdb
+import tensorflow as tf
+import pdb
 
 WEIGHTS_INIT_STDEV = .1
 

--- a/style.py
+++ b/style.py
@@ -1,10 +1,8 @@
 from __future__ import print_function
-import sys, os, pdb
-sys.path.insert(0, 'src')
-import numpy as np, scipy.misc 
-from optimize import optimize
+import os, pdb
+from src.optimize import optimize
 from argparse import ArgumentParser
-from utils import save_img, get_img, exists, list_files
+from src.utils import save_img, get_img, exists, list_files
 import evaluate
 
 CONTENT_WEIGHT = 7.5e0

--- a/transform_video.py
+++ b/transform_video.py
@@ -1,9 +1,7 @@
 from __future__ import print_function
 from argparse import ArgumentParser
-import sys
-sys.path.insert(0, 'src')
 import os, random, subprocess, evaluate, shutil
-from utils import exists, list_files
+from src.utils import exists, list_files
 import pdb
 
 TMP_DIR = '.fns_frames_%s/' % random.randint(0,99999)


### PR DESCRIPTION
This is a follow-up to PR #43:
* turns `src/` into module
* eliminate any use of the `sys.path.insert(0, 'src')` hack
* use py3-compatible syntax for relative imports
* doesn't have PR #43's conflicts
* IDE's like PyCharm should no longer complain

Outstanding issues not handled by this PR:
* there's several imports which are never used and should be cleaned out
* there's a few variables which aren't defined in their context, e.g. `X` and the `get_img()` vs `_get_img()` function
* `src` is probably a bad name for a python module, but I'm leaving as-is