### PR TITLE
remove /style_gram.size in style loss; change tv loss to tensorflow official tv loss function

### DIFF
--- a/src/optimize.py
+++ b/src/optimize.py
@@ -79,7 +79,7 @@ def optimize(content_targets, style_target, content_weight, style_weight,
         style_loss = style_weight * functools.reduce(tf.add, style_losses) / batch_size
 
         # total variation denoising
-        tv_loss = tf.reduce_sum(tf.image.total_variation(preds))/batch_size
+        tv_loss = tv_weight*tf.reduce_sum(tf.image.total_variation(preds))/batch_size
 
         loss = content_loss + style_loss + tv_loss
 

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -74,16 +74,12 @@ def optimize(content_targets, style_target, content_weight, style_weight,
             feats_T = tf.transpose(feats, perm=[0,2,1])
             grams = tf.matmul(feats_T, feats) / size
             style_gram = style_features[style_layer]
-            style_losses.append(2 * tf.nn.l2_loss(grams - style_gram)/style_gram.size)
+            style_losses.append(2 * tf.nn.l2_loss(grams - style_gram))
 
         style_loss = style_weight * functools.reduce(tf.add, style_losses) / batch_size
 
         # total variation denoising
-        tv_y_size = _tensor_size(preds[:,1:,:,:])
-        tv_x_size = _tensor_size(preds[:,:,1:,:])
-        y_tv = tf.nn.l2_loss(preds[:,1:,:,:] - preds[:,:batch_shape[1]-1,:,:])
-        x_tv = tf.nn.l2_loss(preds[:,:,1:,:] - preds[:,:,:batch_shape[2]-1,:])
-        tv_loss = tv_weight*2*(x_tv/tv_x_size + y_tv/tv_y_size)/batch_size
+        tv_loss = tf.reduce_sum(tf.image.total_variation(preds))/batch_size
 
         loss = content_loss + style_loss + tv_loss
 


### PR DESCRIPTION
Hi,
gram matrix is already normalized by size (HxWxC) :
```python
           bs, height, width, filters = map(lambda i:i.value,layer.get_shape())
            size = height * width * filters
            feats = tf.reshape(layer, (bs, height * width, filters))
            feats_T = tf.transpose(feats, perm=[0,2,1])
            grams = tf.matmul(feats_T, feats) / size
```
So I think that it might be wrong to normalize style loss style_gram.size (= num filters**2), since the stlye loss is already normalized by H^2 x W^2 x C^2 after L2 loss (cf. the formulation of style loss in Johnson's paper.)

some problems with self defined tv loss according to [https://en.wikipedia.org/wiki/Total_variation_denoising](url), so changed it to use tensorflow official tv loss function.