### PR TITLE
Fix a little in mislinked word README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Our implementation uses TensorFlow to train a fast style transfer network. We us
 
 ## Documentation
 ### Training Style Transfer Networks
-Use `style.py` to train a new style transfer network. Run `python style.py` to view all the possible parameters. Training takes 4-6 hours on a Maxwell Titan X. [More detailed documentation here](docs.md#style). **Before you run this, you should run `setup.sh`**. Example usage:
+Use `style.py` to train a new style transfer network. Run `python style.py` to view all the possible parameters. Training takes 4-6 hours on a Maxwell Titan X. [More detailed documentation here](docs.md#stylepy). **Before you run this, you should run `setup.sh`**. Example usage:
 
     python style.py --style path/to/style/img.jpg \
       --checkpoint-dir checkpoint/path \
@@ -66,14 +66,14 @@ Use `style.py` to train a new style transfer network. Run `python style.py` to v
       --batch-size 20
 
 ### Evaluating Style Transfer Networks
-Use `evaluate.py` to evaluate a style transfer network. Run `python evaluate.py` to view all the possible parameters. Evaluation takes 100 ms per frame (when batch size is 1) on a Maxwell Titan X. [More detailed documentation here](docs.md#evaluate). Takes several seconds per frame on a CPU. **Models for evaluation are [located here](https://drive.google.com/drive/folders/0B9jhaT37ydSyRk9UX0wwX3BpMzQ?usp=sharing)**. Example usage:
+Use `evaluate.py` to evaluate a style transfer network. Run `python evaluate.py` to view all the possible parameters. Evaluation takes 100 ms per frame (when batch size is 1) on a Maxwell Titan X. [More detailed documentation here](docs.md#evaluatepy). Takes several seconds per frame on a CPU. **Models for evaluation are [located here](https://drive.google.com/drive/folders/0B9jhaT37ydSyRk9UX0wwX3BpMzQ?usp=sharing)**. Example usage:
 
     python evaluate.py --checkpoint path/to/style/model.ckpt \
       --in-path dir/of/test/imgs/ \
       --out-path dir/for/results/
 
 ### Stylizing Video
-Use `transform_video.py` to transfer style into a video. Run `python transform_video.py` to view all the possible parameters. Requires `ffmpeg`. [More detailed documentation here](docs.md#video). Example usage:
+Use `transform_video.py` to transfer style into a video. Run `python transform_video.py` to view all the possible parameters. Requires `ffmpeg`. [More detailed documentation here](docs.md#transform_videopy). Example usage:
 
     python transform_video.py --in-path path/to/input/vid.mp4 \
       --checkpoint path/to/style/model.ckpt \


### PR DESCRIPTION
add extra 'py' for each link on 'More detailed documentation here'.