### PR TITLE
Changed setup to use faster train2014.zip servers

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,5 +4,5 @@ mkdir data
 cd data
 wget http://www.vlfeat.org/matconvnet/models/beta16/imagenet-vgg-verydeep-19.mat
 mkdir bin
-wget http://msvocds.blob.core.windows.net/coco2014/train2014.zip
+wget http://images.cocodataset.org/zips/train2014.zip
 unzip train2014.zip


### PR DESCRIPTION
The new server is the one detailed on the COCO website. It has a significantly faster download time. Verified using md5sum to ensure the zips are the same.