### PR TITLE
Update repo with TensorFlow 2.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,29 @@ We added styles from various paintings to a photo of Chicago. Click on thumbnail
 
 ## Implementation Details
 Our implementation uses TensorFlow to train a fast style transfer network. We use roughly the same transformation network as described in Johnson, except that batch normalization is replaced with Ulyanov's instance normalization, and the scaling/offset of the output `tanh` layer is slightly different. We use a loss function close to the one described in Gatys, using VGG19 instead of VGG16 and typically using "shallower" layers than in Johnson's implementation (e.g. we use `relu1_1` rather than `relu1_2`). Empirically, this results in larger scale style features in transformations.
-
+## Vitual Environment Setup (Anaconda) - Windows/Linux
+Tested on
+| Spec                        |                                                             |
+|-----------------------------|-------------------------------------------------------------|
+| Operating System            | Windows 10 Home                                             |
+| GPU                         | Nvidia GTX 2080 TI                                          |
+| CUDA Version                | 11.0                                                        |
+| Driver Version              | 445.75                                                      |
+### Step 1：Install Anaconda
+https://docs.anaconda.com/anaconda/install/
+### Step 2：Build a virtual environment
+Run the following commands in sequence in Anaconda Prompt:
+```
+conda create -n tf-gpu tensorflow-gpu=2.1.0
+conda activate tf-gpu
+conda install jupyterlab
+jupyter lab
+```
+Run the following command in the notebook or just conda install the package:
+```
+!pip install moviepy==1.0.2
+```
+Follow the commands below to use fast-style-transfer
 ## Documentation
 ### Training Style Transfer Networks
 Use `style.py` to train a new style transfer network. Run `python style.py` to view all the possible parameters. Training takes 4-6 hours on a Maxwell Titan X. [More detailed documentation here](docs.md#stylepy). **Before you run this, you should run `setup.sh`**. Example usage:

--- a/evaluate.py
+++ b/evaluate.py
@@ -26,16 +26,16 @@ def ffwd_video(path_in, path_out, checkpoint_dir, device_t='/gpu:0', batch_size=
                                                     ffmpeg_params=None)
 
     g = tf.Graph()
-    soft_config = tf.ConfigProto(allow_soft_placement=True)
+    soft_config = tf.compat.v1.ConfigProto(allow_soft_placement=True)
     soft_config.gpu_options.allow_growth = True
     with g.as_default(), g.device(device_t), \
-            tf.Session(config=soft_config) as sess:
+            tf.compat.v1.Session(config=soft_config) as sess:
         batch_shape = (batch_size, video_clip.size[1], video_clip.size[0], 3)
-        img_placeholder = tf.placeholder(tf.float32, shape=batch_shape,
+        img_placeholder = tf.compat.v1.placeholder(tf.float32, shape=batch_shape,
                                          name='img_placeholder')
 
         preds = transform.net(img_placeholder)
-        saver = tf.train.Saver()
+        saver = tf.compat.v1.train.Saver()
         if os.path.isdir(checkpoint_dir):
             ckpt = tf.train.get_checkpoint_state(checkpoint_dir)
             if ckpt and ckpt.model_checkpoint_path:
@@ -82,16 +82,16 @@ def ffwd(data_in, paths_out, checkpoint_dir, device_t='/gpu:0', batch_size=4):
     g = tf.Graph()
     batch_size = min(len(paths_out), batch_size)
     curr_num = 0
-    soft_config = tf.ConfigProto(allow_soft_placement=True)
+    soft_config = tf.compat.v1.ConfigProto(allow_soft_placement=True)
     soft_config.gpu_options.allow_growth = True
     with g.as_default(), g.device(device_t), \
-            tf.Session(config=soft_config) as sess:
+            tf.compat.v1.Session(config=soft_config) as sess:
         batch_shape = (batch_size,) + img_shape
-        img_placeholder = tf.placeholder(tf.float32, shape=batch_shape,
+        img_placeholder = tf.compat.v1.placeholder(tf.float32, shape=batch_shape,
                                          name='img_placeholder')
 
         preds = transform.net(img_placeholder)
-        saver = tf.train.Saver()
+        saver = tf.compat.v1.train.Saver()
         if os.path.isdir(checkpoint_dir):
             ckpt = tf.train.get_checkpoint_state(checkpoint_dir)
             if ckpt and ckpt.model_checkpoint_path:

--- a/setup.sh
+++ b/setup.sh
@@ -5,4 +5,4 @@ cd data
 wget http://www.vlfeat.org/matconvnet/models/beta16/imagenet-vgg-verydeep-19.mat
 mkdir bin
 wget http://msvocds.blob.core.windows.net/coco2014/train2014.zip
-unzip train2014.zip
+unzip train2014.zip -q

--- a/setup.sh
+++ b/setup.sh
@@ -5,4 +5,4 @@ cd data
 wget http://www.vlfeat.org/matconvnet/models/beta16/imagenet-vgg-verydeep-19.mat
 mkdir bin
 wget http://msvocds.blob.core.windows.net/coco2014/train2014.zip
-unzip train2014.zip -q
+unzip -q train2014.zip

--- a/src/transform.py
+++ b/src/transform.py
@@ -20,7 +20,7 @@ def net(image):
 def _conv_layer(net, num_filters, filter_size, strides, relu=True):
     weights_init = _conv_init_vars(net, num_filters, filter_size)
     strides_shape = [1, strides, strides, 1]
-    net = tf.nn.conv2d(net, weights_init, strides_shape, padding='SAME')
+    net = tf.nn.conv2d(input=net, filters=weights_init, strides=strides_shape, padding='SAME')
     net = _instance_norm(net)
     if relu:
         net = tf.nn.relu(net)
@@ -30,7 +30,7 @@ def _conv_layer(net, num_filters, filter_size, strides, relu=True):
 def _conv_tranpose_layer(net, num_filters, filter_size, strides):
     weights_init = _conv_init_vars(net, num_filters, filter_size, transpose=True)
 
-    batch_size, rows, cols, in_channels = [i.value for i in net.get_shape()]
+    batch_size, rows, cols, in_channels = [i for i in net.get_shape()]
     new_rows, new_cols = int(rows * strides), int(cols * strides)
     # new_shape = #tf.pack([tf.shape(net)[0], new_rows, new_cols, num_filters])
 
@@ -47,9 +47,9 @@ def _residual_block(net, filter_size=3):
     return net + _conv_layer(tmp, 128, filter_size, 1, relu=False)
 
 def _instance_norm(net, train=True):
-    batch, rows, cols, channels = [i.value for i in net.get_shape()]
+    batch, rows, cols, channels = [i for i in net.get_shape()]
     var_shape = [channels]
-    mu, sigma_sq = tf.nn.moments(net, [1,2], keep_dims=True)
+    mu, sigma_sq = tf.nn.moments(x=net, axes=[1,2], keepdims=True)
     shift = tf.Variable(tf.zeros(var_shape))
     scale = tf.Variable(tf.ones(var_shape))
     epsilon = 1e-3
@@ -57,11 +57,11 @@ def _instance_norm(net, train=True):
     return scale * normalized + shift
 
 def _conv_init_vars(net, out_channels, filter_size, transpose=False):
-    _, rows, cols, in_channels = [i.value for i in net.get_shape()]
+    _, rows, cols, in_channels = [i for i in net.get_shape()]
     if not transpose:
         weights_shape = [filter_size, filter_size, in_channels, out_channels]
     else:
         weights_shape = [filter_size, filter_size, out_channels, in_channels]
 
-    weights_init = tf.Variable(tf.truncated_normal(weights_shape, stddev=WEIGHTS_INIT_STDEV, seed=1), dtype=tf.float32)
+    weights_init = tf.Variable(tf.random.truncated_normal(weights_shape, stddev=WEIGHTS_INIT_STDEV, seed=1), dtype=tf.float32)
     return weights_init

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,23 +1,25 @@
 import scipy.misc, numpy as np, os, sys
+import imageio
+from PIL import Image
 
 def save_img(out_path, img):
     img = np.clip(img, 0, 255).astype(np.uint8)
-    scipy.misc.imsave(out_path, img)
+    imageio.imwrite(out_path, img)
 
 def scale_img(style_path, style_scale):
     scale = float(style_scale)
-    o0, o1, o2 = scipy.misc.imread(style_path, mode='RGB').shape
+    o0, o1, o2 = imageio.imread(style_path, pilmode='RGB').shape
     scale = float(style_scale)
     new_shape = (int(o0 * scale), int(o1 * scale), o2)
     style_target = _get_img(style_path, img_size=new_shape)
     return style_target
 
 def get_img(src, img_size=False):
-   img = scipy.misc.imread(src, mode='RGB') # misc.imresize(, (256, 256, 3))
+   img = imageio.imread(src, pilmode='RGB') # misc.imresize(, (256, 256, 3))
    if not (len(img.shape) == 3 and img.shape[2] == 3):
        img = np.dstack((img,img,img))
    if img_size != False:
-       img = scipy.misc.imresize(img, img_size)
+       img = np.array(Image.fromarray(img).resize(img_size[:2]))
    return img
 
 def exists(p, msg):
@@ -30,4 +32,3 @@ def list_files(in_path):
         break
 
     return files
-

--- a/src/vgg.py
+++ b/src/vgg.py
@@ -50,13 +50,13 @@ def net(data_path, input_image):
 
 
 def _conv_layer(input, weights, bias):
-    conv = tf.nn.conv2d(input, tf.constant(weights), strides=(1, 1, 1, 1),
+    conv = tf.nn.conv2d(input=input, filters=tf.constant(weights), strides=(1, 1, 1, 1),
             padding='SAME')
     return tf.nn.bias_add(conv, bias)
 
 
 def _pool_layer(input):
-    return tf.nn.max_pool(input, ksize=(1, 2, 2, 1), strides=(1, 2, 2, 1),
+    return tf.nn.max_pool2d(input=input, ksize=(1, 2, 2, 1), strides=(1, 2, 2, 1),
             padding='SAME')
 
 


### PR DESCRIPTION
Updates the repo code to enable comparability with TensorFlow 2.0 using tf_upgrade_v2 utility tool.

Tested and working on:
Spec |  
-- | --
Operating System | Windows 10 Home
GPU | Nvidia GTX 2080 TI
CUDA Version | 11.0
Driver Version | 445.75

Updated the readme with conda instructions for  working with TensorFlow 2.0

Merged @divisiondeariza https://github.com/lengstrom/fast-style-transfer/pull/220 fork in to my fork to fix scipy issues. 
