### PR TITLE
Update Core ML reference links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ You will need the following to run the above:
 - The image of the Stata Center at the very beginning of the README was taken by [Juan Paulo](https://juanpaulo.me/)
 
 ### Related Work
-- Michael Ramos ported this network [to use CoreML on iOS](https://medium.com/@rambossa/diy-prisma-fast-style-transfer-app-with-coreml-and-tensorflow-817c3b90dacd)
+- [Michael Ramos](https://twitter.com/backnotprop) ported this network [to use CoreML on iOS](https://github.com/backnotprop/fast-style-transfer-coreml)


### PR DESCRIPTION
@lengstrom thanks for keeping the reference around... I'd like to update my links... 

1. Updated coreml implementation link to the GitHub repository. Medium typically has a paywall. It's still linked from my github.

2. (optional) added a twitter, as I move back into this type of AI work I'd like to be able to better network.