### PR TITLE
Update setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,5 +4,5 @@ mkdir data
 cd data
 wget http://www.vlfeat.org/matconvnet/models/beta16/imagenet-vgg-verydeep-19.mat
 mkdir bin
-wget http://msvocds.blob.core.windows.net/coco2014/train2014.zip
+wget http://images.cocodataset.org/zips/train2014.zip
 unzip -q train2014.zip


### PR DESCRIPTION
fix broken url
Current url gets the following response: 409 Public access is not permitted on this storage account.

I'm not sure if this is the right url to use, but it seems to be the same file.